### PR TITLE
Add optimized TinyTC code

### DIFF
--- a/alternatives/drivers/BK1_tinytc.cc
+++ b/alternatives/drivers/BK1_tinytc.cc
@@ -1,3 +1,7 @@
+// Copyright (C) 2025 Leibniz-Rechenzentrum
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 /*
 Input Parameters for Kernels;
 nm : Number of the node on each direction
@@ -5,85 +9,103 @@ nq : Number of the gauss points on each direction
 nelmt : Number of finite elements
 basis : 1D basis functions on each dimension (l0, l1 etc.)
 
-wsp : intermediate storages 
+wsp : intermediate storages
 */
 
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <random>
 #include <sycl/sycl.hpp>
 #include <tinytc/tinytc.hpp>
 #include <tinytc/tinytc_sycl.hpp>
-
-#include <iostream>
-#include <fstream>
-#include <cstdio>
-#include <numeric>
-#include <vector>
-#include <cmath>
-#include <array>
 #include <tuple>
-
+#include <vector>
 
 class Timer {
-public:
-    void start(){
+   public:
+    void start() {
         m_StartTime = m_clock::now();
-        m_bRunning  = true;
+        m_bRunning = true;
     }
 
-    void stop(){
-        m_EndTime  = m_clock::now();
+    void stop() {
+        m_EndTime = m_clock::now();
         m_bRunning = false;
     }
 
-    double elapsedNanoseconds(){
+    double elapsedNanoseconds() {
         auto endTime = m_bRunning ? m_clock::now() : m_EndTime;
-        return std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - m_StartTime).count();
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(endTime -
+                                                                    m_StartTime)
+            .count();
     }
 
-    double elapsedSeconds(){
-        return elapsedNanoseconds() / 1.0e9;
-    }
+    double elapsedSeconds() { return elapsedNanoseconds() / 1.0e9; }
 
-private:
+   private:
     using m_clock = std::chrono::high_resolution_clock;
     std::chrono::time_point<m_clock> m_StartTime{};
     std::chrono::time_point<m_clock> m_EndTime{};
     bool m_bRunning = false;
 };
 
-
-template<typename T, int nq0, int nq1, int nq2>
-void run_test(
-    sycl::queue &queue,
-    sycl::kernel_bundle<sycl::bundle_state::executable>& bundle,
-    const unsigned int nelmt,
-    const unsigned int ntests,
-    bool show_norm)
-{
+template <typename T>
+void run_test(sycl::queue &queue, const int nq0, const int nq1, const int nq2,
+              const std::int64_t nelmt, const std::int64_t ntests,
+              bool show_norm, bool init_random = false) {
     const int nm0 = nq0 - 1;
     const int nm1 = nq1 - 1;
     const int nm2 = nq2 - 1;
 
-    std::vector<T> basis0(nm0 * nq0), basis1(nm1 * nq1), basis2(nm2 * nq2);
+    const auto nq0_pad = [&]() {
+        int nq0_pad = 1;
+        while (nq0_pad < nq0) {
+            nq0_pad *= 2;
+        }
+        return nq0_pad;
+    }();
+    const auto nq1_pad = nq0_pad;
+    const auto nq2_pad = nq0_pad;
 
-    //Initialize the input and output arrays
+    std::vector<T> basis0(nq0_pad * nq0_pad, T{0}),
+        basis1(nq1_pad * nq1_pad, T{0}), basis2(nq2_pad * nq2_pad, T{0});
+
+    // Initialize the input and output arrays
     std::vector<T> JxW(nelmt * nq0 * nq1 * nq2, (T)1.0);
     std::vector<T> in(nelmt * nm0 * nm1 * nm2, (T)3.0);
     std::vector<T> out(nelmt * nm0 * nm1 * nm2, (T)0.0);
 
-    //Initialization of basis functions
-    for(unsigned int p = 0u; p < nq0; p++) {
-        for(unsigned int i = 0u; i < nm0; i++) {
-            basis0[p * nm0 + i] = std::cos((T)(p * nm0 + i));
+    if (init_random) {
+        auto rd = std::random_device{};
+        auto gen = std::minstd_rand(rd());
+        auto dis = std::uniform_real_distribution<>(-1.0, 1.0);
+        for (auto &j : JxW) {
+            j = dis(gen);
+        }
+        for (auto &i : in) {
+            i = dis(gen);
         }
     }
-    for(unsigned int q = 0u; q < nq1; q++) {
-        for(unsigned int j = 0u; j < nm1; j++) {
-            basis1[q * nm1 + j] = std::cos((T)(q * nm1 + j));
+
+    // Initialization of basis functions
+    for (unsigned int p = 0u; p < nq0; p++) {
+        for (unsigned int i = 0u; i < nm0; i++) {
+            basis0[p * nq0_pad + i] = std::cos((T)(p * nm0 + i));
         }
     }
-    for(unsigned int r = 0u; r < nq2; r++) {
-        for(unsigned int k = 0u; k < nm2; k++) {
-            basis2[r * nm2 + k] = std::cos((T)(r * nm2 + k));
+    for (unsigned int q = 0u; q < nq1; q++) {
+        for (unsigned int j = 0u; j < nm1; j++) {
+            basis1[q * nq1_pad + j] = std::cos((T)(q * nm1 + j));
+        }
+    }
+    for (unsigned int r = 0u; r < nq2; r++) {
+        for (unsigned int k = 0u; k < nm2; k++) {
+            basis2[r * nq2_pad + k] = std::cos((T)(r * nm2 + k));
         }
     }
 
@@ -94,88 +116,140 @@ void run_test(
     const size_t size_basis1 = basis1.size();
     const size_t size_basis2 = basis2.size();
 
-    T *d_JxW    = sycl::malloc_device<T>(size_JxW, queue);
-    T *d_in     = sycl::malloc_device<T>(size_in, queue);
-    T *d_out    = sycl::malloc_device<T>(size_out, queue);
+    T *d_JxW = sycl::malloc_device<T>(size_JxW, queue);
+    T *d_in = sycl::malloc_device<T>(size_in, queue);
+    T *d_out = sycl::malloc_device<T>(size_out, queue);
     T *d_basis0 = sycl::malloc_device<T>(size_basis0, queue);
     T *d_basis1 = sycl::malloc_device<T>(size_basis1, queue);
     T *d_basis2 = sycl::malloc_device<T>(size_basis2, queue);
 
-    queue.copy(in.data(),d_in,size_in);
-    queue.copy(JxW.data(),d_JxW,size_JxW);
-    queue.copy(basis0.data(),d_basis0,size_basis0);
-    queue.copy(basis1.data(),d_basis1,size_basis1);
-    queue.copy(basis2.data(),d_basis2,size_basis2);
+    queue.copy(in.data(), d_in, size_in);
+    queue.copy(JxW.data(), d_JxW, size_JxW);
+    queue.copy(basis0.data(), d_basis0, size_basis0);
+    queue.copy(basis1.data(), d_basis1, size_basis1);
+    queue.copy(basis2.data(), d_basis2, size_basis2);
     queue.wait_and_throw();
-
-//    const size_t localSize = std::min(nq0 * nq1 * nq2, (int) threadsPerBlock);
-//    const size_t globalSize = numBlocks * localSize;
-
-//    const sycl::nd_range<1> kernelRange{{globalSize},{localSize}};
-
-//    const std::array<unsigned int,3> nms{nm0,nm1,nm2};
-//    const std::array<unsigned int,3> nqs{nq0,nq1,nq2};
-
-//    const std::array<int,3> nq_sf{nq0,nq1,nq2};
 
     // Performance in GDoF/s
     auto dof_rate = [=](double elapsed) {
         return 1.0e-9 * nelmt * nm0 * nm1 * nm2 / elapsed;
     };
+    auto byte_rate = [=](double elapsed) {
+        return 1.0e-9 * sizeof(float) * nelmt *
+               (2 * nm0 * nm1 * nm2 + nq0 * nq1 * nq2) / elapsed;
+    };
 
     {
-        const size_t howmany = nelmt;
-        auto bk1_kernel = tinytc::create_kernel(bundle, "sum_factorization");
+        auto info = tinytc::create_core_info(queue.get_device());
+        // tinytc::set_core_features(info.get(),
+        // tinytc_core_feature_flag_large_register_file);
+
+        auto ctx = tinytc::create_compiler_context();
+        tinytc::set_error_reporter(
+            ctx.get(), [](char const *what, const tinytc_location_t *, void *) {
+                std::cerr << what << std::endl;
+            });
+
+        // Parse program bundle
+
+        char const *kernel_name = "sum_factorization_block_pre";
+        constexpr std::size_t block_size = 16;
+        // char const *kernel_name = "sum_factorization";
+        // constexpr std::size_t block_size = 1;
+        auto code_stream = std::ifstream("sum_factorization.ir");
+        auto code_template =
+            std::string(std::istreambuf_iterator<char>(code_stream),
+                        std::istreambuf_iterator<char>());
+
+        const auto wgs = [&]() {
+            switch (nq0) {
+                case 2:
+                case 3:
+                    return 32;
+                case 4:
+                    return 64;
+                case 5:
+                    return 128;
+                case 6:
+                    return 256;
+                case 7:
+                case 8:
+                    return 512;
+                default:
+                    break;
+            }
+            return 32;
+        }();
+        auto code = (std::ostringstream{} << "$P = " << nm0 << "\n"
+                                          << "$Q_pad = " << nq0_pad << "\n"
+                                          << "$B = " << block_size << "\n"
+                                          << "$wgs = " << wgs << "\n"
+                                          << code_template)
+                        .str();
+        auto prog = tinytc::parse_string(code, ctx.get());
+
+        auto bin =
+            tinytc::compile_to_spirv_and_assemble(prog.get(), info.get());
+
+        auto bundle = tinytc::create_kernel_bundle(
+            queue.get_context(), queue.get_device(), bin.get());
+
+        auto bk1_kernel = tinytc::create_kernel(bundle, kernel_name);
         auto exe_range = tinytc::get_execution_range(
-            bk1_kernel, sycl::range<3u>{1u,1u,howmany});
+            bk1_kernel,
+            sycl::range<3u>{1u, 1u,
+                            static_cast<std::size_t>(nelmt) / block_size});
 
         double time_cl = std::numeric_limits<double>::max();
         Timer clTimer;
 
-        for (unsigned int t = 0u; t < ntests; ++t)
-        {
+        for (unsigned int t = 0u; t < ntests; ++t) {
             clTimer.start();
 
-            queue.submit([=](sycl::handler &h){
-                h.set_args(d_basis0,d_basis1,d_basis2,d_JxW,howmany,d_in,howmany,d_out,howmany);
-                h.parallel_for(exe_range,bk1_kernel);
-            }).wait_and_throw();
+            queue
+                .submit([=](sycl::handler &h) {
+                    h.set_args(d_basis0, d_basis1, d_basis2, d_JxW, nelmt, d_in,
+                               nelmt, d_out, nelmt);
+                    h.parallel_for(exe_range, bk1_kernel);
+                })
+                .wait_and_throw();
 
             clTimer.stop();
             time_cl = std::min(time_cl, clTimer.elapsedSeconds());
         }
 
-        std::cout << "# TinyTC -> nelmt " << nelmt << " GDoF/s = " << dof_rate(time_cl) << '\n';
-
+        std::cout << "# TinyTC -> nelmt " << nelmt
+                  << " GDoF/s = " << dof_rate(time_cl) << '\n';
+        std::cout << "# TinyTC -> nelmt " << nelmt
+                  << " GB/s = " << byte_rate(time_cl) << '\n';
     }
 
     if (show_norm) {
-
         // 2. Copy data from device buffer d_out to host buffer out
-        queue.copy(d_out,out.data(),out.size()).wait_and_throw();
+        queue.copy(d_out, out.data(), out.size()).wait_and_throw();
 
         double normSqr{0.0};
         for (auto h : out) {
-            normSqr += ((double) h) * ((double) h);
+            normSqr += ((double)h) * ((double)h);
         }
 
-        std::cout << "# TinyTC kernel norm = " << std::sqrt(normSqr) << '\n';
+        std::cout << "# SYCL kernel norm = " << std::sqrt(normSqr) << '\n';
     }
-
 }
 
+int main(int argc, char **argv) {
+    const unsigned int nq0 = argc > 1 ? atoi(argv[1]) : 4;
+    const unsigned int nq1 = nq0;
+    const unsigned int nq2 = nq0;
 
-int main(int argc, char **argv){
+    unsigned int nelmt = argc > 2 ? atoi(argv[2]) : 2 << 18;
+    unsigned int ntests = argc > 3 ? atoi(argv[3]) : 5u;
 
-    const unsigned int nq0 = 4;
-    const unsigned int nq1 = 4;
-    const unsigned int nq2 = 4;
+    const char *env = getenv("SHOW_NORM");
+    const bool show_norm = (env && strcmp(env, "1") == 0);
 
-    unsigned int nelmt              = (argc > 1) ? atoi(argv[1]) : 2 << 18;
-    unsigned int ntests             = (argc > 2) ? atoi(argv[2]) : 5u;
-
-    const char *env = std::getenv("SHOW_NORM");
-    bool show_norm = (env && strcmp(env, "1") == 0);
+    const char *env_rnd = getenv("INIT_RANDOM");
+    const bool init_random = (env_rnd && strcmp(env_rnd, "1") == 0);
 
     try {
         // This tries to create a queue on a GPU device if available,
@@ -184,38 +258,31 @@ int main(int argc, char **argv){
 
         auto device = queue.get_device();
 
-        std::cout << "# Device name: " << device.get_info<sycl::info::device::name>() << '\n';
-        std::cout << "#   Max Compute Units (EUs): " << device.get_info<sycl::info::device::max_compute_units>() << '\n';
-        std::cout << "#   Max Work Group Size: " << device.get_info<sycl::info::device::max_work_group_size>() << '\n';
+        std::cout << "# Device name: "
+                  << device.get_info<sycl::info::device::name>() << '\n';
+        std::cout << "#   Max Compute Units (EUs): "
+                  << device.get_info<sycl::info::device::max_compute_units>()
+                  << '\n';
+        std::cout << "#   Max Work Group Size: "
+                  << device.get_info<sycl::info::device::max_work_group_size>()
+                  << '\n';
         std::cout << "#   Sub-group Sizes: ";
-        for (const auto &s : device.get_info<sycl::info::device::sub_group_sizes>()) {
+        for (const auto &s :
+             device.get_info<sycl::info::device::sub_group_sizes>()) {
             std::cout << s << " ";
         }
         std::cout << std::endl;
 
-        auto info = tinytc::create_core_info(device);
-        tinytc::set_core_features(info.get(), tinytc_core_feature_flag_large_register_file);
+        // Now you can set kernel arguments and enqueue kernel as shown
+        // before
+        run_test<float>(queue, nq0, nq1, nq2, nelmt, ntests, show_norm,
+                        init_random);
 
-        auto ctx = tinytc::create_compiler_context();
-        tinytc::set_error_reporter(ctx.get(), [](char const *what, const tinytc_location_t *, void *) {
-           std::cerr << what << std::endl;
-        });
-
-
-        // Parse program bundle
-        auto prog = tinytc::parse_file("sum_factorization.ir", ctx.get());
-
-        auto bin = tinytc::compile_to_spirv_and_assemble(prog.get(), info.get());
-
-        auto bundle = tinytc::create_kernel_bundle(queue.get_context(), device, bin.get());
-
-        // Now you can set kernel arguments and enqueue kernel as shown before
-        run_test<float,nq0,nq1,nq2>(queue, bundle, nelmt, ntests, show_norm);
-
-    } catch (tinytc::status const& st) {
-        std::cerr << "tinytc: Error (" << static_cast<int>(st) << ")" << std::endl;
+    } catch (tinytc::status const &st) {
+        std::cerr << "tinytc: Error (" << static_cast<int>(st) << ")"
+                  << std::endl;
         return 1;
-    } catch (sycl::exception const& e) {
+    } catch (sycl::exception const &e) {
         std::cerr << "SYCL exception caught: " << e.what() << std::endl;
         return 1;
     }

--- a/alternatives/sum_factorization.ir
+++ b/alternatives/sum_factorization.ir
@@ -1,3 +1,159 @@
+; Copyright (C) 2025 Leibniz-Rechenzentrum
+; Copyright (C) 2025 Intel Corporation
+; SPDX-License-Identifier: Apache-2.0
+
+;$P = 3
+;$B = 16
+;$wgs = 128
+;$Q_pad = 4
+$Q = !calc($P 1 +)
+$P2 = !calc($P $P *)
+$P3 = !calc($P2 $P *)
+$Q2 = !calc($Q $Q *)
+$Q3 = !calc($Q2 $Q *)
+$BP = !calc($B $P *)
+$BP2 = !calc($B $P2 *)
+$BQ = !calc($B $Q *)
+$BQ3 = !calc($B $Q3 *)
+
+func @sum_factorization_block_pre(%basis0: memref<f32x$P x$Q,strided<1,$Q_pad>>,
+                                  %basis1: memref<f32x$P x$Q,strided<1,$Q_pad>>,
+                                  %basis2: memref<f32x$P x$Q,strided<1,$Q_pad>>,
+                                  %JxW:    memref<f32x$B x$Q x$Q x$Q x?>,
+                                  %in:     memref<f32x$B x$P x$P x$P x?>,
+                                  %out:    memref<f32x$B x$P x$P x$P x?>) 
+attributes{subgroup_size=16,work_group_size=[$wgs,1]}
+{
+    %gid = group_id.x : index                                ; Get our index e
+
+    %c0 = constant 0 : index
+    %cB = constant $B : index
+    %cP = constant $P : index
+    %cQ = constant $Q : index
+    %cQ2 = constant $Q2 : index
+    %cQ3 = constant $Q3 : index
+    %cBP = constant $BP : index
+    %cBP2 = constant $BP2 : index
+    %cBPQ = mul %cBP, %cQ : index
+    %cBQ2 = mul %cB, %cQ2 : index
+
+    %block_begin = mul %gid, %cB : index
+
+    %J_e = subview %JxW[0:$B,0:$Q,0:$Q,0:$Q,%gid] : memref<f32x$B x$Q x$Q x$Q>
+    %in_e = subview %in[0:$B,0:$P,0:$P,0:$P,%gid] : memref<f32x$B x$P x$P x$P>
+    %out_e = subview %out[0:$B,0:$P,0:$P,0:$P,%gid] : memref<f32x$B x$P x$P x$P>
+
+    %alpha1 = constant 1.0 : f32
+    %beta0 = constant 0.0 : f32
+
+; Direction 0: wsp1_(BIJ)c   := in_(BIJ)K basis0_Kc
+
+    %wsp2 = alloca : memref<f32x$B x$P x$Q x$Q, local> ; Reserve temporary memory
+    %wsp1 = alloca : memref<f32x$B x$P x$P x$Q,local>
+
+    %tmp1 = fuse %in_e[0,2] : memref<f32x$BP2 x$P>
+    %res1 = fuse %wsp1[0,2] : memref<f32x$BP2 x$Q,local>
+    ;gemm.n.n %alpha1, %tmp1, %basis0, %beta0, %res1
+    foreach_tile (%i)=(%c0),(%cBP2) as (%t0)<=(16) {
+        %0 = constant 0.0 : coopmatrix<f32x16x$Q,matrix_acc>
+        %1 = cooperative_matrix_load.cols_checked %tmp1[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_a>
+        %2 = cooperative_matrix_load %basis0[%c0,%c0] : coopmatrix<f32x$Q_pad x$Q,matrix_b>
+        %3 = cooperative_matrix_mul_add %1, %2, %0 : coopmatrix<f32x16x$Q,matrix_acc>
+        cooperative_matrix_store %3, %res1[%i,%c0]
+    }
+
+; Direction 1: wsp2_(BI)b[c] := wsp1_(BI)J[c] basis1_Jb
+
+    %wsp1_fused = fuse %wsp1[0,1] : memref<f32x$BP x$P x$Q,local>
+    %wsp2_fused = fuse %wsp2[0,1] : memref<f32x$BP x$Q x$Q,local>
+
+    barrier.local
+    foreach_tile (%tile0)=(%c0),(%cBPQ) as (%t0)<=(16) {
+        %i = rem %tile0, %cBP : index
+        %c = div %tile0, %cBP : index
+        %tmp = subview %wsp1_fused[0:$BP,0:$P,%c] : memref<f32x$BP x$P,local>
+        %res = subview %wsp2_fused[0:$BP,0:$Q,%c] : memref<f32x$BP x$Q,local>
+
+        %0 = constant 0.0 : coopmatrix<f32x16x$Q,matrix_acc>
+        %1 = cooperative_matrix_load.cols_checked %tmp[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_a>
+        %2 = cooperative_matrix_load %basis1[%c0,%c0] : coopmatrix<f32x$Q_pad x$Q,matrix_b>
+        %3 = cooperative_matrix_mul_add %1, %2, %0 : coopmatrix<f32x16x$Q,matrix_acc>
+        cooperative_matrix_store %3, %res[%i,%c0]
+    }
+
+
+; Direction 2: wsp3_Ba[b][c] := wsp2_BI[b][c] basis2_Ia
+; Multiply with weights and determinant of Jacobi: wsp3_B(abc)   := J_(abc)B wsp3_B(abc)
+; Direction 2 (reverse): wsp4_Bi[b][c] := wsp3_Ba[b][c] basis2_ia
+
+    %wsp4 = alloca : memref<f32x$B x$P x$Q x$Q, local>
+
+    barrier.local
+    foreach_tile (%tile0)=(%c0),(%cBQ2) as (%t0)<=(16) {
+        %i = rem %tile0, %cB : index
+        %bc = div %tile0, %cB : index
+        %b = rem %bc, %cQ : index
+        %c = div %bc, %cQ : index
+        %tmp = subview %wsp2[0:$B,0:$P,%b,%c] : memref<f32x$B x$P,local>
+
+        %0 = constant 0.0 : coopmatrix<f32x16x$Q_pad,matrix_acc>
+        %1 = cooperative_matrix_load.cols_checked %tmp[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_a>
+        %2 = cooperative_matrix_load %basis2[%c0,%c0] : coopmatrix<f32x$Q_pad x$Q_pad,matrix_b>
+        %acc = cooperative_matrix_mul_add %1, %2, %0 : coopmatrix<f32x16x$Q_pad,matrix_acc>
+
+        %J_sub = subview %J_e[0:$B,0:$Q,%b,%c] : memref<f32x$B x$Q>
+        %J_bc = cooperative_matrix_load.cols_checked %J_sub[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_acc>
+        %acc_scaled = mul %J_bc, %acc : coopmatrix<f32x16x$Q_pad,matrix_acc>
+
+        %3 = constant 0.0 : coopmatrix<f32x16x$P,matrix_acc>
+        %4 = cast %acc_scaled : coopmatrix<f32x16x$Q_pad,matrix_a> 
+        %5 = cooperative_matrix_load.t %basis2[%c0,%c0] : coopmatrix<f32x$Q_pad x$P,matrix_b>
+        %6 = cooperative_matrix_mul_add %4, %5, %3 : coopmatrix<f32x16x$P,matrix_acc>
+
+        %res = subview %wsp4[0:$B,0:$P,%b,%c] : memref<f32x$B x$P,local>
+        cooperative_matrix_store %6, %res[%i,%c0]
+    }
+
+; Direction 1 (reverse): wsp5_(Bi)j[c] := wsp4_(Bi)b[c] basis1_jb
+
+    %wsp5 = alloca : memref<f32x$B x$P x$P x$Q, local>
+
+    %wsp4_fused = fuse %wsp4[0,1] : memref<f32x$BP x$Q x$Q,local>
+    %wsp5_fused = fuse %wsp5[0,1] : memref<f32x$BP x$P x$Q,local>
+
+    barrier.local
+    foreach_tile (%tile0)=(%c0),(%cBPQ) as (%t0)<=(16) {
+        %i = rem %tile0, %cBP : index
+        %c = div %tile0, %cBP : index
+        %tmp = subview %wsp4_fused[0:$BP,0:$Q,%c] : memref<f32x$BP x$Q,local>
+        %res = subview %wsp5_fused[0:$BP,0:$P,%c] : memref<f32x$BP x$P,local>
+
+        %0 = constant 0.0 : coopmatrix<f32x16x$P,matrix_acc>
+        %1 = cooperative_matrix_load %tmp[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_a>
+        %2 = cooperative_matrix_load.t %basis1[%c0,%c0] : coopmatrix<f32x$Q_pad x$P,matrix_b>
+        %3 = cooperative_matrix_mul_add %1, %2, %0 : coopmatrix<f32x16x$P,matrix_acc>
+        cooperative_matrix_store %3, %res[%i,%c0]
+    }
+
+; Direction 0 (reverse): out_(Bij)k    := wsp6_(Bij)c basis0_kc
+
+    %wsp5_fused2 = fuse %wsp5[0,2] : memref<f32x$BP2 x$Q,local>
+    %out_fused = fuse %out_e[0,2] : memref<f32x$BP2 x$P>
+
+    barrier.local
+    ;gemm.n.t %alpha1, %wsp5_fused2, %basis0, %beta0, %out_fused
+    foreach_tile (%i)=(%c0),(%cBP2) as (%t0)<=(16) {
+        %0 = constant 0.0 : coopmatrix<f32x16x$P,matrix_acc>
+        %1 = cooperative_matrix_load.cols_checked %wsp5_fused2[%i,%c0] : coopmatrix<f32x16x$Q_pad,matrix_a>
+        %2 = cooperative_matrix_load.t %basis0[%c0,%c0] : coopmatrix<f32x$Q_pad x$P,matrix_b>
+        %3 = cooperative_matrix_mul_add %1, %2, %0 : coopmatrix<f32x16x$P,matrix_acc>
+        cooperative_matrix_store %3, %out_fused[%i,%c0]
+    }
+}
+
+
+
+
 func @sum_factorization(%basis0: memref<f32x3x4>,
                         %basis1: memref<f32x3x4>,
                         %basis2: memref<f32x3x4>,
@@ -24,7 +180,7 @@ func @sum_factorization(%basis0: memref<f32x3x4>,
     %res1 = fuse %wsp1[0,1] : memref<f32x9x4,local>    
     gemm.n.n %c1, %tmp1, %basis0, %c0, %res1
     
-: Direction 1
+; Direction 1
 
     %dir1_from = constant 0 : index
     %dir2_to   = constant 4 : index  
@@ -63,7 +219,7 @@ func @sum_factorization(%basis0: memref<f32x3x4>,
         gemm.n.t %c1, %tmp, %basis1, %c0, %res
     }
 
-: Direction 0 (reverse)
+; Direction 0 (reverse)
 
     %dir0r_from = constant 0 : index
     %dir0r_to   = constant 3 : index


### PR DESCRIPTION
Optimized TinyTC kernels for BK1 problem. Also adds support for nq != 4 via TinyTC's "pre-processor".

Notes:
- Tensor format is changed from PxPxPxN to BxPxPxPx(N/B) where B is the native vector width (= 16)
- The basis function matrices are padded to the next power of two to avoid boundary checks
- Work-group size needs to increase with polynomial degree because higher SLM usage decreases max number of work-groups that can be dispatched per XeCore
- For performance measurements on the Arc B580 one needs to set INIT_RANDOM=1. For constant initial data the memory compression kicks in and the results are overly optimistic :-)